### PR TITLE
Adds opening PHP tag to example config

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ Add configuration for Twigpack is done via the `config.php` config file. Here's 
 ### The `config.php` File
 
 ```php
+<?php
+
 return [
     // Global settings
     '*' => [


### PR DESCRIPTION
Thanks for a fantastic plugin, it really does a great job of welcoming webpack into Craft development :) 

I was being silly, and copied the code directly from the example to start with. I don't think I will be the only person to do this, so I'm proposing to add the opening PHP tag to the example.

Thanks again.