### PR TITLE
added getModuleHash() function, to grab the hash key of a module. Use…

### DIFF
--- a/src/helpers/Manifest.php
+++ b/src/helpers/Manifest.php
@@ -243,6 +243,40 @@ EOT;
         return $module;
     }
 
+	/**
+	 * Return the HASH value from to module
+	 *
+	 * @param array  $config
+	 * @param string $moduleName
+	 * @param string $type
+	 * @param bool   $soft
+	 *
+	 * @return null|string
+	 * @throws NotFoundHttpException
+	 */
+	public static function getModuleHash(array $config, string $moduleName, string $type = 'modern', bool $soft = false)
+	{
+
+		try {
+			// Get the module entry
+			$module = self::getModuleEntry($config, $moduleName, $type, $soft);
+			if ($module !== null) {
+				$prefix = self::$isHot
+					? $config['devServer']['publicPath']
+					: $config['server']['publicPath'];
+				// Extract only the Hash Value
+				$modulePath = pathinfo($module);
+				$moduleFilename = $modulePath['filename'];
+				$moduleHash = substr($moduleFilename, strpos($moduleFilename, ".") + 1);
+			}
+		} catch (Exception $e) {
+			// return emtpt string if no module is found
+			return '';
+		}
+
+		return $moduleHash;
+	}
+
     /**
      * Return a module's raw entry from the manifest
      *

--- a/src/services/Manifest.php
+++ b/src/services/Manifest.php
@@ -131,7 +131,25 @@ class Manifest extends Component
         return ManifestHelper::getModule($config, $moduleName, $type);
     }
 
-    /**
+	/**
+	 * Return the HASH value from a module
+	 *
+	 * @param string $moduleName
+	 * @param string $type
+	 * @param null   $config
+	 *
+	 * @return null|string
+	 * @throws NotFoundHttpException
+	 */
+	public function getModuleHash(string $moduleName, string $type = 'modern', $config = null)
+	{
+		$settings = Twigpack::$plugin->getSettings();
+		$config = $config ?? $settings->getAttributes();
+
+		return ManifestHelper::getModuleHash($config, $moduleName, $type);
+	}
+
+	/**
      * Returns the contents of a file from a URI path
      *
      * @param string $path

--- a/src/variables/ManifestVariable.php
+++ b/src/variables/ManifestVariable.php
@@ -119,6 +119,23 @@ class ManifestVariable
         );
     }
 
+	/**
+	 * Return the HASH value from a module
+	 *
+	 * @param string $moduleName
+	 * @param string $type
+	 * @param null   $config
+	 *
+	 * @return null|Markup
+	 * @throws NotFoundHttpException
+	 */
+	public function getModuleHash(string $moduleName, string $type = 'modern', $config = null)
+	{
+		return Template::raw(
+			Twigpack::$plugin->manifest->getModuleHash($moduleName, $type, $config)
+		);
+	}
+
     /**
      * Include the Safari 10.1 nomodule fix JavaScript
      *


### PR DESCRIPTION
… case is e.g. using the hash as a cookie value eg. critical css or cache busting.
```twig
{% set assetHash = craft.twigpack.getModuleHash("styles.css", "legacy") %}
```

