### PR TITLE
Add timeout for file_get_contents

### DIFF
--- a/src/helpers/Manifest.php
+++ b/src/helpers/Manifest.php
@@ -527,6 +527,7 @@ EOT;
                             'verify_peer_name' => false,
                         ],
                         'http' => [
+                            'timeout' => 5,
                             'ignore_errors' => true,
                             'header' => "User-Agent:Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.8.1.13) Gecko/20080311 Firefox/2.0.0.13\r\n",
                         ],


### PR DESCRIPTION
Hello,

I ran into an issue where I was not running the webpack-dev-server and kept getting timeout exceptions and this was due to it was not timing out while attempting to get the manifest. So it would take 20+ seconds to load a single page. Obviously this is not ideal, so I added a short timeout (the webpack-dev-server should respond with the manifest instantly but I set it to 5 seconds just incase)

Thoughts?