### PR TITLE
Allow for Relative URLs

### DIFF
--- a/src/config.php
+++ b/src/config.php
@@ -28,6 +28,8 @@ return [
     '*' => [
         // If `devMode` is on, use webpack-dev-server to all for HMR (hot module reloading)
         'useDevServer' => false,
+        // Enforce Absolute URLs on includes 
+        'useAbsoluteUrl' => true,
         // The JavaScript entry from the manifest.json to inject on Twig error pages
         'errorEntry' => '',
         // String to be appended to the cache key

--- a/src/helpers/Manifest.php
+++ b/src/helpers/Manifest.php
@@ -221,8 +221,9 @@ EOT;
             $prefix = self::$isHot
                 ? $config['devServer']['publicPath']
                 : $config['server']['publicPath'];
-            // If the module isn't a full URL, prefix it
-            if (!UrlHelper::isAbsoluteUrl($module)) {
+            $useAbsoluteUrl = $config['useAbsoluteUrl'];
+            // If the module isn't a full URL, prefix it as required
+            if ($useAbsoluteUrl && !UrlHelper::isAbsoluteUrl($module)) {
                 $module = self::combinePaths($prefix, $module);
             }
             // Resolve any aliases
@@ -230,8 +231,8 @@ EOT;
             if ($alias) {
                 $module = $alias;
             }
-            // Make sure it's a full URL
-            if (!UrlHelper::isAbsoluteUrl($module) && !is_file($module)) {
+            // Make sure it's a full URL, as required
+            if ($useAbsoluteUrl && !UrlHelper::isAbsoluteUrl($module) && !is_file($module)) {
                 try {
                     $module = UrlHelper::siteUrl($module);
                 } catch (Exception $e) {

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -30,6 +30,11 @@ class Settings extends Model
     public $useDevServer = true;
 
     /**
+     * @var bool If true, enforces Absolute Urls, if false, allows relative
+     */
+    public $useAbsoluteUrl = true;
+    
+    /**
      * @var string The JavaScript entry from the manifest.json to inject on
      *      Twig error pages
      */


### PR DESCRIPTION
We have been having some issues with CORS errors between our origin server and our cache provider, which is the front for our origin server. (prod.website.corporation.com is fronted by www.corporation.com) By changing these references to relative URLs they load from the correct server regardless of the name.
