### PR TITLE
Added support for loading a particular webpack build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Twigpack Changelog
 
+## 1.3.0 - 2020-03-18
+### Added
+* Added the config setting `devServerBuildType` to determine which webpack-dev-server bundle is loaded.
+
 ## 1.2.0 - 2020-02-28
 ### Changed
 * Switched over to using `media="print"` for asynchronously loading a stylesheet as per [The Simplest Way to Load CSS Asynchronously](https://www.filamentgroup.com/lab/load-css-simpler/)

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "nystudio107/craft-twigpack",
     "description": "Twigpack is a bridge between Twig and webpack, with manifest.json & webpack-dev-server HMR support",
     "type": "craft-plugin",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "keywords": [
         "craftcms",
         "craft-plugin",

--- a/src/config.php
+++ b/src/config.php
@@ -49,6 +49,8 @@ return [
             'manifestPath' => 'http://localhost:8080/',
             'publicPath' => 'http://localhost:8080/',
         ],
+        // Bundle to use with the webpack-dev-server
+        'devServerBuildType' => 'modern',
         // Local files config
         'localFiles' => [
             'basePath' => '@webroot/',

--- a/src/helpers/Manifest.php
+++ b/src/helpers/Manifest.php
@@ -333,10 +333,11 @@ EOT;
             $manifestPath = self::$isHot
                 ? $config['devServer']['manifestPath']
                 : $config['server']['manifestPath'];
-            // If this is a dev-server, only look for the modern manifest
+            // If this is a dev-server, use the defined build type
             $thisType = $type;
+            $devServerBuildType = $config['devServerBuildType'];
             if (self::$isHot) {
-                $thisType = 'modern';
+                $thisType = ($devServerBuildType === 'combined' ? $thisType : $devServerBuildType);
             }
             // Normalize the path
             $path = self::combinePaths($manifestPath, $config['manifest'][$thisType]);

--- a/src/helpers/Manifest.php
+++ b/src/helpers/Manifest.php
@@ -335,9 +335,10 @@ EOT;
                 : $config['server']['manifestPath'];
             // If this is a dev-server, use the defined build type
             $thisType = $type;
-            $devServerBuildType = $config['devServerBuildType'];
             if (self::$isHot) {
-                $thisType = ($devServerBuildType === 'combined' ? $thisType : $devServerBuildType);
+                $thisType = $config['devServerBuildType'] === 'combined'
+                    ? $thisType
+                    : $config['devServerBuildType'];
             }
             // Normalize the path
             $path = self::combinePaths($manifestPath, $config['manifest'][$thisType]);

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -33,7 +33,7 @@ class Settings extends Model
      * @var bool If true, enforces Absolute Urls, if false, allows relative
      */
     public $useAbsoluteUrl = true;
-    
+
     /**
      * @var string The JavaScript entry from the manifest.json to inject on
      *      Twig error pages
@@ -68,6 +68,12 @@ class Settings extends Model
         'manifestPath' => 'http://localhost:8080/',
         'publicPath' => 'http://localhost:8080/',
     ];
+
+    /**
+     * @var string defines which bundle will be used from the webpack dev server.
+     *      Can be 'modern', 'legacy' or 'combined'. Defaults to 'modern'.
+     */
+    public $devServerBuildType = 'modern';
 
     /**
      * @var array Local files config


### PR DESCRIPTION
We recently encountered a use case where we needed to test legacy builds on browser stack (IE11) whilst running the site locally with webpack-dev-server. As Twigpack is hard coded to load the modern bundle while running the dev server, I needed a way to control which bundle was loaded.

I therefore added a new config setting called `devServerBuildType` which can be set to `modern`, `legacy` or `combined`. It defaults to `modern` for backwards compatibility and dictates which bundle is loaded via Twigpack.

I've setup my webpack dev config to accept an environment variable to only output the desired bundles (see https://gist.github.com/thejoshsmith/9cee9cfdaa52d3b60716eab150c02d16), but this is not required.