### PR TITLE
Make manifest file cache duration configurable for devServer

### DIFF
--- a/src/config.php
+++ b/src/config.php
@@ -52,6 +52,8 @@ return [
         ],
         // Bundle to use with the webpack-dev-server
         'devServerBuildType' => 'modern',
+        // Cache webpack dev server manifest file for 1 second
+        'devServerManifestCacheDuration' => 1,
         // Whether to include a Content Security Policy "nonce" for inline
         // CSS or JavaScript. Valid values are 'header' or 'tag' for how the CSP
         // should be included. c.f.:

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -76,6 +76,12 @@ class Settings extends Model
     public $devServerBuildType = 'modern';
 
     /**
+     * @var int defines for how many seconds the manifest file from the webpack dev server is cached.
+     *      Any integer greater than 0 is valid. Defaults to 1.
+     */
+    public $devServerManifestCacheDuration = 1;
+
+    /**
      * @var string Whether to include a Content Security Policy "nonce" for inline
      *      CSS or JavaScript. Valid values are 'header' or 'tag' for how the CSP
      *      should be included. c.f.:
@@ -105,6 +111,7 @@ class Settings extends Model
             ['useDevServer', 'default', 'value' => true],
             ['errorEntry', 'string'],
             ['devServerBuildType', 'string'],
+            ['devServerManifestCacheDuration', 'number', 'integerOnly' => true, 'min' => 1 ],
             ['cspNonce', 'string'],
             [
                 [


### PR DESCRIPTION
### Description

I have experienced some multi-second loading times (in with dev server), which could be traced back to how the manifest was being loaded / cached.
To mitigate the problem, I have added some 2 method parameters and 1 setting model property to allow the manifest cache duration to be configured in the twigpack.php config file.

In my problem case, a page has loaded for an average of 4.7 seconds (devMode + webpack-dev-server). With the modifications in this PR I was able to set the cache duration much higher and got the loading time down to 0.7s. Due to the fact that the manifest.json from the webpack-dev-server never changes in my case (no hash in the module file names), the caching doesn't produce any loading errors.

Cheers mate :)
