### PR TITLE
Fix malformed HTTP request to mix-manifest.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Twigpack Changelog
 
+## Unreleased
+
+### Fixed
+* Fixed a malformed `User-Agent` header in a request to `mix-manifest.json`
+
 ## 1.2.12 - 2021.04.05
 ### Changed
 * Catch all errors thrown by Guzzle

--- a/src/helpers/Manifest.php
+++ b/src/helpers/Manifest.php
@@ -612,7 +612,7 @@ EOT;
                     try {
                         $response = $client->request('GET', $path, [
                             RequestOptions::HEADERS => [
-                                'User-Agent' => "User-Agent:Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.8.1.13) Gecko/20080311 Firefox/2.0.0.13\r\n",
+                                'User-Agent' => "User-Agent:Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.8.1.13) Gecko/20080311 Firefox/2.0.0.13",
                                 'Accept' => '*/*',
                             ],
                         ]);


### PR DESCRIPTION
### Description

Fixed a malformed `User-Agent` header in a request to `mix-manifest.json`

### Related issues

https://github.com/nystudio107/craft-twigpack/issues/62