### PR TITLE
Craft Cloud: docs & deploy event

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,5 +36,8 @@
     "class": "nystudio107\\twigpack\\Twigpack",
     "handle": "twigpack",
     "name": "Twigpack"
+  },
+  "require-dev": {
+    "craftcms/cloud": "^1.37"
   }
 }

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -447,14 +447,16 @@ This will output:
 
 ## Craft Cloud
 
-Craft Cloud deploys build artifacts to a CDN, so you'll need to configure `config/twipack.php` to use the CDN URL:  
+Craft Cloud deploys build artifacts to a CDN, so you'll need to configure Twigpack to use the CDN URL:  
 
 ```php
+<?php
+// config/twigpack.php
 return [
-     'server' => [
-         'manifestPath' => \craft\cloud\Helper::artifactUrl('dist/'),
-         'publicPath' => \craft\cloud\Helper::artifactUrl('dist/'),
-     ],
+    'server' => [
+        'manifestPath' => \craft\cloud\Helper::artifactUrl('dist/'),
+        'publicPath' => \craft\cloud\Helper::artifactUrl('dist/'),
+    ],
 ];
 ```
 
@@ -464,11 +466,13 @@ in a Craft Cloud environment, and `@web/dist/` otherwise.
 If you'd like to use a different path all together when working locally, you can use the `\craft\cloud\Helper::isCraftCloud()`:
 
 ```php
+<?php
+// config/twigpack.php
 return [
-     'server' => [
-         'manifestPath' => \craft\cloud\Helper::isCraftCloud() ? \craft\cloud\Helper::artifactUrl('dist/') : '@webroot/dist/',
-         'publicPath' => \craft\cloud\Helper::artifactUrl('dist/'),
-     ],
+    'server' => [
+        'manifestPath' => \craft\cloud\Helper::isCraftCloud() ? \craft\cloud\Helper::artifactUrl('dist/') : '@webroot/dist/',
+        'publicPath' => \craft\cloud\Helper::artifactUrl('dist/'),
+    ],
 ];
 ```
 
@@ -476,6 +480,7 @@ Additionally, your Webpack configuration should have `output.publicPath` configu
 In Craft Cloud's build pipeline, this is exposed as an `CRAFT_CLOUD_ARTIFACT_BASE_URL` environment variable.
 
 ```javascript
+// webpack.config.js
 import webpack from 'webpack';
 
 export default {

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -1,10 +1,10 @@
 ---
-title: Twigpack plugin for Craft CMS 3.x
+title: Twigpack plugin for Craft CMS 4.x
 description: Twigpack is a bridge between Twig and webpack, with manifest.json & webpack-dev-server HMR support
 ---
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/nystudio107/craft-twigpack/badges/quality-score.png?b=v1)](https://scrutinizer-ci.com/g/nystudio107/craft-twigpack/?branch=v1) [![Code Coverage](https://scrutinizer-ci.com/g/nystudio107/craft-twigpack/badges/coverage.png?b=v1)](https://scrutinizer-ci.com/g/nystudio107/craft-twigpack/?branch=v1) [![Build Status](https://scrutinizer-ci.com/g/nystudio107/craft-twigpack/badges/build.png?b=v1)](https://scrutinizer-ci.com/g/nystudio107/craft-twigpack/build-status/v1) [![Code Intelligence Status](https://scrutinizer-ci.com/g/nystudio107/craft-twigpack/badges/code-intelligence.svg?b=v1)](https://scrutinizer-ci.com/code-intelligence)
 
-# Twigpack plugin for Craft CMS 3.x
+# Twigpack plugin for Craft CMS 4.x
 
 Twigpack is a bridge between Twig and webpack, with manifest.json & webpack-dev-server HMR support
 
@@ -14,7 +14,7 @@ Related Article: [An Annotated webpack 4 Config for Frontend Web Development](ht
 
 ## Requirements
 
-This plugin requires Craft CMS 3.0.0 or later.
+This plugin requires Craft CMS 4.0.0 or later.
 
 ## Installation
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -447,37 +447,48 @@ This will output:
 
 ## Craft Cloud
 
-Craft Cloud deploys build artifacts to a CDN, so you'll need to configure Twigpack to use the CDN URL:  
+During a [build](https://craftcms.com/knowledge-base/cloud-builds), Craft Cloud deploys static assets to a CDN, so you’ll need to configure Twigpack to use the appropriate URLs:
 
 ```php
 <?php
 // config/twigpack.php
+
+use craft\cloud\Helper as CloudHelper;
+
 return [
     'server' => [
-        'manifestPath' => \craft\cloud\Helper::artifactUrl('dist/'),
-        'publicPath' => \craft\cloud\Helper::artifactUrl('dist/'),
+        'manifestPath' => CloudHelper::artifactUrl('dist/'),
+        'publicPath' => CloudHelper::artifactUrl('dist/'),
     ],
 ];
 ```
 
-The `\craft\cloud\Helper::artifactUrl()` function will return a URL like `https://cdn.craft.com/{uuid}/builds/{uuid}/artifacts/dist/`
-in a Craft Cloud environment, and `@web/dist/` otherwise.
+This helper function returns a CDN URL that includes your project and environment identifiers, like this:
 
-If you'd like to use a different path all together when working locally, you can use the `\craft\cloud\Helper::isCraftCloud()`:
+```
+https://cdn.craft.com/{project-uuid}/builds/{environment-uuid}/artifacts/dist/
+```
+
+Outside of Cloud, `CloudHelper::artifactUrl()` evaluates the passed string as though it were prepended with the `@web` alias.
+
+If you’d prefer to use an on-disk `manifestPath` when working locally (instead of a URL), the `CloudHelper::isCraftCloud()` function lets you switch based on the environment:
 
 ```php
 <?php
 // config/twigpack.php
+
+use craft\cloud\Helper as CloudHelper;
+
 return [
     'server' => [
-        'manifestPath' => \craft\cloud\Helper::isCraftCloud() ? \craft\cloud\Helper::artifactUrl('dist/') : '@webroot/dist/',
-        'publicPath' => \craft\cloud\Helper::artifactUrl('dist/'),
+        'manifestPath' => CloudHelper::isCraftCloud() ? CloudHelper::artifactUrl('dist/') : '@webroot/dist/',
+        'publicPath' => CloudHelper::artifactUrl('dist/'),
     ],
 ];
 ```
 
-Additionally, your Webpack configuration should have `output.publicPath` configured to use the same CDN URL.
-In Craft Cloud's build pipeline, this is exposed as an `CRAFT_CLOUD_ARTIFACT_BASE_URL` environment variable.
+Additionally, your Webpack configuration should have `output.publicPath` set to the same CDN URL.
+In Craft Cloud’s build pipeline, this is exposed as a [`CRAFT_CLOUD_ARTIFACT_BASE_URL` environment variable](https://craftcms.com/knowledge-base/cloud-builds#build-command):
 
 ```javascript
 // webpack.config.js

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -445,6 +445,46 @@ This will output:
 </style>
 ```
 
+## Craft Cloud
+
+Craft Cloud deploys build artifacts to a CDN, so you'll need to configure `config/twipack.php` to use the CDN URL:  
+
+```php
+return [
+     'server' => [
+         'manifestPath' => \craft\cloud\Helper::artifactUrl('dist/'),
+         'publicPath' => \craft\cloud\Helper::artifactUrl('dist/'),
+     ],
+];
+```
+
+The `\craft\cloud\Helper::artifactUrl()` function will return a URL like `https://cdn.craft.com/{uuid}/builds/{uuid}/artifacts/dist/`
+in a Craft Cloud environment, and `@web/dist/` otherwise.
+
+If you'd like to use a different path all together when working locally, you can use the `\craft\cloud\Helper::isCraftCloud()`:
+
+```php
+return [
+     'server' => [
+         'manifestPath' => \craft\cloud\Helper::isCraftCloud() ? \craft\cloud\Helper::artifactUrl('dist/') : '@webroot/dist/',
+         'publicPath' => \craft\cloud\Helper::artifactUrl('dist/'),
+     ],
+];
+```
+
+Additionally, your Webpack configuration should have `output.publicPath` configured to use the same CDN URL.
+In Craft Cloud's build pipeline, this is exposed as an `CRAFT_CLOUD_ARTIFACT_BASE_URL` environment variable.
+
+```javascript
+import webpack from 'webpack';
+
+export default {
+  output: {
+    publicPath: `${process.env.CRAFT_CLOUD_ARTIFACT_BASE_URL || ''}/dist/`,
+  },
+};
+```
+
 ## Just for Fun
 
 Here’s a video of hot module replacement of a Vue JS component, using Twigpack as the bridge:

--- a/src/Twigpack.php
+++ b/src/Twigpack.php
@@ -197,6 +197,7 @@ class Twigpack extends Plugin
                 );
             }
         );
+        // Clears cache after craft cloud/up is run, which Craft Cloud runs on deploy
         // Handler: UpController::EVENT_AFTER_UP
         if (class_exists(UpController::class)) {
             Event::on(

--- a/src/Twigpack.php
+++ b/src/Twigpack.php
@@ -14,6 +14,8 @@ namespace nystudio107\twigpack;
 use Craft;
 use craft\base\Model;
 use craft\base\Plugin;
+use craft\cloud\cli\controllers\UpController;
+use craft\events\CancelableEvent;
 use craft\events\PluginEvent;
 use craft\events\RegisterCacheOptionsEvent;
 use craft\events\TemplateEvent;
@@ -195,6 +197,17 @@ class Twigpack extends Plugin
                 );
             }
         );
+        // Handler: UpController::EVENT_AFTER_UP
+        if (class_exists(UpController::class)) {
+            Event::on(
+                UpController::class,
+                UpController::EVENT_AFTER_UP,
+                function (CancelableEvent $event) {
+                    $this->clearAllCaches();
+                }
+            );
+        }
+
         // delay attaching event handler to the view component after it is fully configured
         $app = Craft::$app;
         if ($app->getConfig()->getGeneral()->devMode) {


### PR DESCRIPTION
- Adds Craft Cloud docs and examples
- Listens for a deploy event and clears cache

/cc @augustmiller